### PR TITLE
Fix compatibility Warning with Greebo version

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -57,7 +57,7 @@ class syntax_plugin_cellbg extends DokuWiki_Syntax_Plugin {
  
  
     // Handle the match
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         switch ($state) {
           case DOKU_LEXER_ENTER :
             break;
@@ -77,7 +77,7 @@ class syntax_plugin_cellbg extends DokuWiki_Syntax_Plugin {
     }
  
     // Create output
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml'){
           list($state, $color, $text) = $data;
           switch ($state) {


### PR DESCRIPTION
@dr4Ke Please, merge this Pull Request to fix these compatibility Warnings with Greebo version
```
Warning: Declaration of syntax_plugin_cellbg::handle($match, $state, $pos, &$handler) should be compatible with DokuWiki_Syntax_Plugin::handle($match, $state, $pos, Doku_Handler $handler) in /membri/mk4duowiki/wiki/lib/plugins/cellbg/syntax.php on line 123

Warning: Declaration of syntax_plugin_cellbg::render($mode, &$renderer, $data) should be compatible with DokuWiki_Syntax_Plugin::render($format, Doku_Renderer $renderer, $data) in /membri/mk4duowiki/wiki/lib/plugins/cellbg/syntax.php on line 123
```